### PR TITLE
Fix webpack error of expo-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.31.11",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "expo-cli": "^6.0.8",
+        "expo-cli": "6.0.5",
         "prettier": "^2.7.1",
         "typescript": "4.8.3"
       },
@@ -2933,51 +2933,23 @@
       }
     },
     "node_modules/@expo/schemer": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@expo/schemer/-/schemer-1.4.4.tgz",
-      "integrity": "sha512-cZo7hhjuEpOl5qf8nidZPlusRX4GXWRh24pOkM6LP2FGLMNdfazcJj1TU6h3h9FY5G6xLfGxpDhF/JETL9Qj+A==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@expo/schemer/-/schemer-1.4.3.tgz",
+      "integrity": "sha512-upaic2flgWfJLE70ZIBZFG9Vh0ilgVn50DZIJ8+EY0xugl2hB5FXYxTlCtQkJXjou78ADC6fKqJsm1drMxpy3A==",
       "dev": true,
       "dependencies": {
-        "ajv": "^8.1.0",
-        "ajv-formats": "^2.0.2",
-        "json-schema-traverse": "^1.0.0",
-        "lodash": "^4.17.21",
-        "probe-image-size": "^7.1.0",
+        "ajv": "^6.12.6",
+        "json-schema-traverse": "0.3.1",
+        "lodash": "^4.17.19",
+        "probe-image-size": "~6.0.0",
         "read-chunk": "^3.2.0"
       }
     },
-    "node_modules/@expo/schemer/node_modules/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@expo/schemer/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
       "dev": true
-    },
-    "node_modules/@expo/schemer/node_modules/probe-image-size": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
-      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
-      "dev": true,
-      "dependencies": {
-        "lodash.merge": "^4.6.2",
-        "needle": "^2.5.2",
-        "stream-parser": "~0.3.1"
-      }
     },
     "node_modules/@expo/sdk-runtime-versions": {
       "version": "1.0.0",
@@ -3007,9 +2979,9 @@
       "integrity": "sha512-TI+l71+5aSKnShYclFa14Kum+hQMZ86b95SH6tQUG3qZEmLTarvWpKwqtTwQKqvlJSJrpFiSFu3eCuZokY6zWA=="
     },
     "node_modules/@expo/webpack-config": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-0.17.3.tgz",
-      "integrity": "sha512-EcnHHmMscC7mL7qGQpXoSSpOrXbyfnMErUfqaBVjMYz7I4xVvoPQqiM13v4JXnz9TnZHDxD9t7+VSa9hPJVssA==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-0.17.2.tgz",
+      "integrity": "sha512-cgcWyVXUEH5wj4InAPCIDHAGgpkQhpzWseCj4xVjdL3paBKRMWVjPUqmdHh/exap3U0kHGr/XS+e7ZWLcgHkUw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.9.0",
@@ -3018,7 +2990,7 @@
         "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "~6.0.3",
         "css-loader": "~3.6.0",
-        "expo-pwa": "0.0.124",
+        "expo-pwa": "0.0.123",
         "file-loader": "~6.0.0",
         "find-yarn-workspace-root": "~2.0.0",
         "getenv": "^1.0.0",
@@ -11305,9 +11277,9 @@
       }
     },
     "node_modules/expo-cli": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/expo-cli/-/expo-cli-6.0.8.tgz",
-      "integrity": "sha512-ZVQ47l/wFsPgF9S68MT3mQCCq0HEH4wggnDdd3keZBHV8uhC1TvkdufOeWgbr7/uP5oKdfXEOQCXaYbJPdd69A==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/expo-cli/-/expo-cli-6.0.5.tgz",
+      "integrity": "sha512-A2ZkQVHWUNFPjb61ZCgbZbLdqOSDSlT9vyhijIa0MDmvTUbO4i1r2S8UInndmW0vyRxmmYvvgHDj0J3xaoKuqw==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.9.0",
@@ -11319,7 +11291,7 @@
         "@expo/json-file": "8.2.36",
         "@expo/osascript": "2.0.33",
         "@expo/package-manager": "0.0.56",
-        "@expo/plist": "0.0.19",
+        "@expo/plist": "0.0.18",
         "@expo/prebuild-config": "4.0.3",
         "@expo/spawn-async": "1.5.0",
         "@expo/xcpretty": "^4.1.0",
@@ -11365,7 +11337,7 @@
         "url-join": "4.0.0",
         "uuid": "^8.0.0",
         "wrap-ansi": "^7.0.0",
-        "xdl": "59.2.55"
+        "xdl": "59.2.52"
       },
       "bin": {
         "expo": "bin/expo.js",
@@ -11553,17 +11525,6 @@
         "getenv": "^1.0.0",
         "resolve-from": "^5.0.0",
         "sucrase": "^3.20.0"
-      }
-    },
-    "node_modules/expo-cli/node_modules/@expo/plist": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.19.tgz",
-      "integrity": "sha512-9+GdsnLOZ475bITOSwU6MxIXukYHS3yTVCK2+cSDMyb9h2NuBwpnHFJGFUqcg9HcA6fbmyhGnNpPD3vk7zqWFQ==",
-      "dev": true,
-      "dependencies": {
-        "@xmldom/xmldom": "~0.7.6",
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^14.0.0"
       }
     },
     "node_modules/expo-cli/node_modules/@expo/prebuild-config": {
@@ -11956,12 +11917,12 @@
       }
     },
     "node_modules/expo-pwa": {
-      "version": "0.0.124",
-      "resolved": "https://registry.npmjs.org/expo-pwa/-/expo-pwa-0.0.124.tgz",
-      "integrity": "sha512-hYvQQhxATNTivWSRc9nrd1WVYJJnBG8P/SVrJ4PPu0pmsS7ZIvWt981IXYG461y9UWnTbXdZEG4UOt0Thak1Gg==",
+      "version": "0.0.123",
+      "resolved": "https://registry.npmjs.org/expo-pwa/-/expo-pwa-0.0.123.tgz",
+      "integrity": "sha512-zLueqATI+bvvjAfPHErrQ/jnsAN1/Jy46/K0TjdVvvCPoouVym6+1LhIEUUDAHTNJBOb9BIav9WxlrFb5/h3KA==",
       "dev": true,
       "dependencies": {
-        "@expo/image-utils": "0.3.23",
+        "@expo/image-utils": "0.3.22",
         "chalk": "^4.0.0",
         "commander": "2.20.0",
         "update-check": "1.5.3"
@@ -11974,9 +11935,9 @@
       }
     },
     "node_modules/expo-pwa/node_modules/@expo/image-utils": {
-      "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.3.23.tgz",
-      "integrity": "sha512-nhUVvW0TrRE4jtWzHQl8TR4ox7kcmrc2I0itaeJGjxF5A54uk7avgA0wRt7jP1rdvqQo1Ke1lXyLYREdhN9tPw==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.3.22.tgz",
+      "integrity": "sha512-uzq+RERAtkWypOFOLssFnXXqEqKjNj9eXN7e97d/EXUAojNcLDoXc0sL+F5B1I4qtlsnhX01kcpoIBBZD8wZNQ==",
       "dev": true,
       "dependencies": {
         "@expo/spawn-async": "1.5.0",
@@ -25256,9 +25217,9 @@
       }
     },
     "node_modules/xdl": {
-      "version": "59.2.55",
-      "resolved": "https://registry.npmjs.org/xdl/-/xdl-59.2.55.tgz",
-      "integrity": "sha512-6XLpWpPFUsjH2gwpvCMRx4vJjszRonX1UxF8LpLYdZi0jZB1fvppweUYJjdQ8RaS62pEm3TBRq+JwB0RIFlFwA==",
+      "version": "59.2.52",
+      "resolved": "https://registry.npmjs.org/xdl/-/xdl-59.2.52.tgz",
+      "integrity": "sha512-OUPiONKR3UHdZu71ynfxI0uEQ/ID8OqmstlzKVKyne3ZXdT9bQ4oHLrhQxMJPi2tiizItTLnb30r+KIwOe/7yw==",
       "dev": true,
       "dependencies": {
         "@expo/bunyan": "4.0.0",
@@ -25269,12 +25230,12 @@
         "@expo/json-file": "8.2.36",
         "@expo/osascript": "2.0.33",
         "@expo/package-manager": "0.0.56",
-        "@expo/plist": "0.0.19",
+        "@expo/plist": "0.0.18",
         "@expo/rudder-sdk-node": "1.1.1",
-        "@expo/schemer": "1.4.4",
+        "@expo/schemer": "1.4.3",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "@expo/spawn-async": "1.5.0",
-        "@expo/webpack-config": "0.17.3",
+        "@expo/webpack-config": "0.17.2",
         "axios": "0.21.1",
         "better-opn": "^3.0.1",
         "boxen": "^5.0.1",
@@ -25369,17 +25330,6 @@
         "xml2js": "0.4.23"
       }
     },
-    "node_modules/xdl/node_modules/@expo/config-plugins/node_modules/@expo/plist": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.18.tgz",
-      "integrity": "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==",
-      "dev": true,
-      "dependencies": {
-        "@xmldom/xmldom": "~0.7.0",
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^14.0.0"
-      }
-    },
     "node_modules/xdl/node_modules/@expo/config-plugins/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -25436,17 +25386,6 @@
         "getenv": "^1.0.0",
         "resolve-from": "^5.0.0",
         "sucrase": "^3.20.0"
-      }
-    },
-    "node_modules/xdl/node_modules/@expo/plist": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.19.tgz",
-      "integrity": "sha512-9+GdsnLOZ475bITOSwU6MxIXukYHS3yTVCK2+cSDMyb9h2NuBwpnHFJGFUqcg9HcA6fbmyhGnNpPD3vk7zqWFQ==",
-      "dev": true,
-      "dependencies": {
-        "@xmldom/xmldom": "~0.7.6",
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^14.0.0"
       }
     },
     "node_modules/xdl/node_modules/axios": {
@@ -27781,47 +27720,23 @@
       }
     },
     "@expo/schemer": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@expo/schemer/-/schemer-1.4.4.tgz",
-      "integrity": "sha512-cZo7hhjuEpOl5qf8nidZPlusRX4GXWRh24pOkM6LP2FGLMNdfazcJj1TU6h3h9FY5G6xLfGxpDhF/JETL9Qj+A==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@expo/schemer/-/schemer-1.4.3.tgz",
+      "integrity": "sha512-upaic2flgWfJLE70ZIBZFG9Vh0ilgVn50DZIJ8+EY0xugl2hB5FXYxTlCtQkJXjou78ADC6fKqJsm1drMxpy3A==",
       "dev": true,
       "requires": {
-        "ajv": "^8.1.0",
-        "ajv-formats": "^2.0.2",
-        "json-schema-traverse": "^1.0.0",
-        "lodash": "^4.17.21",
-        "probe-image-size": "^7.1.0",
+        "ajv": "^6.12.6",
+        "json-schema-traverse": "0.3.1",
+        "lodash": "^4.17.19",
+        "probe-image-size": "~6.0.0",
         "read-chunk": "^3.2.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "8.11.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-          "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
         "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
           "dev": true
-        },
-        "probe-image-size": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
-          "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
-          "dev": true,
-          "requires": {
-            "lodash.merge": "^4.6.2",
-            "needle": "^2.5.2",
-            "stream-parser": "~0.3.1"
-          }
         }
       }
     },
@@ -27850,9 +27765,9 @@
       "integrity": "sha512-TI+l71+5aSKnShYclFa14Kum+hQMZ86b95SH6tQUG3qZEmLTarvWpKwqtTwQKqvlJSJrpFiSFu3eCuZokY6zWA=="
     },
     "@expo/webpack-config": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-0.17.3.tgz",
-      "integrity": "sha512-EcnHHmMscC7mL7qGQpXoSSpOrXbyfnMErUfqaBVjMYz7I4xVvoPQqiM13v4JXnz9TnZHDxD9t7+VSa9hPJVssA==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-0.17.2.tgz",
+      "integrity": "sha512-cgcWyVXUEH5wj4InAPCIDHAGgpkQhpzWseCj4xVjdL3paBKRMWVjPUqmdHh/exap3U0kHGr/XS+e7ZWLcgHkUw==",
       "dev": true,
       "requires": {
         "@babel/core": "7.9.0",
@@ -27861,7 +27776,7 @@
         "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "~6.0.3",
         "css-loader": "~3.6.0",
-        "expo-pwa": "0.0.124",
+        "expo-pwa": "0.0.123",
         "file-loader": "~6.0.0",
         "find-yarn-workspace-root": "~2.0.0",
         "getenv": "^1.0.0",
@@ -34424,9 +34339,9 @@
       }
     },
     "expo-cli": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/expo-cli/-/expo-cli-6.0.8.tgz",
-      "integrity": "sha512-ZVQ47l/wFsPgF9S68MT3mQCCq0HEH4wggnDdd3keZBHV8uhC1TvkdufOeWgbr7/uP5oKdfXEOQCXaYbJPdd69A==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/expo-cli/-/expo-cli-6.0.5.tgz",
+      "integrity": "sha512-A2ZkQVHWUNFPjb61ZCgbZbLdqOSDSlT9vyhijIa0MDmvTUbO4i1r2S8UInndmW0vyRxmmYvvgHDj0J3xaoKuqw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "7.9.0",
@@ -34438,7 +34353,7 @@
         "@expo/json-file": "8.2.36",
         "@expo/osascript": "2.0.33",
         "@expo/package-manager": "0.0.56",
-        "@expo/plist": "0.0.19",
+        "@expo/plist": "0.0.18",
         "@expo/prebuild-config": "4.0.3",
         "@expo/spawn-async": "1.5.0",
         "@expo/xcpretty": "^4.1.0",
@@ -34484,7 +34399,7 @@
         "url-join": "4.0.0",
         "uuid": "^8.0.0",
         "wrap-ansi": "^7.0.0",
-        "xdl": "59.2.55"
+        "xdl": "59.2.52"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -34651,17 +34566,6 @@
             "getenv": "^1.0.0",
             "resolve-from": "^5.0.0",
             "sucrase": "^3.20.0"
-          }
-        },
-        "@expo/plist": {
-          "version": "0.0.19",
-          "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.19.tgz",
-          "integrity": "sha512-9+GdsnLOZ475bITOSwU6MxIXukYHS3yTVCK2+cSDMyb9h2NuBwpnHFJGFUqcg9HcA6fbmyhGnNpPD3vk7zqWFQ==",
-          "dev": true,
-          "requires": {
-            "@xmldom/xmldom": "~0.7.6",
-            "base64-js": "^1.2.3",
-            "xmlbuilder": "^14.0.0"
           }
         },
         "@expo/prebuild-config": {
@@ -34978,21 +34882,21 @@
       }
     },
     "expo-pwa": {
-      "version": "0.0.124",
-      "resolved": "https://registry.npmjs.org/expo-pwa/-/expo-pwa-0.0.124.tgz",
-      "integrity": "sha512-hYvQQhxATNTivWSRc9nrd1WVYJJnBG8P/SVrJ4PPu0pmsS7ZIvWt981IXYG461y9UWnTbXdZEG4UOt0Thak1Gg==",
+      "version": "0.0.123",
+      "resolved": "https://registry.npmjs.org/expo-pwa/-/expo-pwa-0.0.123.tgz",
+      "integrity": "sha512-zLueqATI+bvvjAfPHErrQ/jnsAN1/Jy46/K0TjdVvvCPoouVym6+1LhIEUUDAHTNJBOb9BIav9WxlrFb5/h3KA==",
       "dev": true,
       "requires": {
-        "@expo/image-utils": "0.3.23",
+        "@expo/image-utils": "0.3.22",
         "chalk": "^4.0.0",
         "commander": "2.20.0",
         "update-check": "1.5.3"
       },
       "dependencies": {
         "@expo/image-utils": {
-          "version": "0.3.23",
-          "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.3.23.tgz",
-          "integrity": "sha512-nhUVvW0TrRE4jtWzHQl8TR4ox7kcmrc2I0itaeJGjxF5A54uk7avgA0wRt7jP1rdvqQo1Ke1lXyLYREdhN9tPw==",
+          "version": "0.3.22",
+          "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.3.22.tgz",
+          "integrity": "sha512-uzq+RERAtkWypOFOLssFnXXqEqKjNj9eXN7e97d/EXUAojNcLDoXc0sL+F5B1I4qtlsnhX01kcpoIBBZD8wZNQ==",
           "dev": true,
           "requires": {
             "@expo/spawn-async": "1.5.0",
@@ -45614,9 +45518,9 @@
       }
     },
     "xdl": {
-      "version": "59.2.55",
-      "resolved": "https://registry.npmjs.org/xdl/-/xdl-59.2.55.tgz",
-      "integrity": "sha512-6XLpWpPFUsjH2gwpvCMRx4vJjszRonX1UxF8LpLYdZi0jZB1fvppweUYJjdQ8RaS62pEm3TBRq+JwB0RIFlFwA==",
+      "version": "59.2.52",
+      "resolved": "https://registry.npmjs.org/xdl/-/xdl-59.2.52.tgz",
+      "integrity": "sha512-OUPiONKR3UHdZu71ynfxI0uEQ/ID8OqmstlzKVKyne3ZXdT9bQ4oHLrhQxMJPi2tiizItTLnb30r+KIwOe/7yw==",
       "dev": true,
       "requires": {
         "@expo/bunyan": "4.0.0",
@@ -45627,12 +45531,12 @@
         "@expo/json-file": "8.2.36",
         "@expo/osascript": "2.0.33",
         "@expo/package-manager": "0.0.56",
-        "@expo/plist": "0.0.19",
+        "@expo/plist": "0.0.18",
         "@expo/rudder-sdk-node": "1.1.1",
-        "@expo/schemer": "1.4.4",
+        "@expo/schemer": "1.4.3",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "@expo/spawn-async": "1.5.0",
-        "@expo/webpack-config": "0.17.3",
+        "@expo/webpack-config": "0.17.2",
         "axios": "0.21.1",
         "better-opn": "^3.0.1",
         "boxen": "^5.0.1",
@@ -45727,17 +45631,6 @@
             "xml2js": "0.4.23"
           },
           "dependencies": {
-            "@expo/plist": {
-              "version": "0.0.18",
-              "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.18.tgz",
-              "integrity": "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==",
-              "dev": true,
-              "requires": {
-                "@xmldom/xmldom": "~0.7.0",
-                "base64-js": "^1.2.3",
-                "xmlbuilder": "^14.0.0"
-              }
-            },
             "semver": {
               "version": "7.3.8",
               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -45790,17 +45683,6 @@
             "getenv": "^1.0.0",
             "resolve-from": "^5.0.0",
             "sucrase": "^3.20.0"
-          }
-        },
-        "@expo/plist": {
-          "version": "0.0.19",
-          "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.19.tgz",
-          "integrity": "sha512-9+GdsnLOZ475bITOSwU6MxIXukYHS3yTVCK2+cSDMyb9h2NuBwpnHFJGFUqcg9HcA6fbmyhGnNpPD3vk7zqWFQ==",
-          "dev": true,
-          "requires": {
-            "@xmldom/xmldom": "~0.7.6",
-            "base64-js": "^1.2.3",
-            "xmlbuilder": "^14.0.0"
           }
         },
         "axios": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "expo-cli": "^6.0.8",
+    "expo-cli": "6.0.5",
     "prettier": "^2.7.1",
     "typescript": "4.8.3"
   }


### PR DESCRIPTION
Fixed:

```
Error: Cannot find module '@expo/dev-server/build/webpack/symbolicateMiddleware'
Require stack:
```

It seems because of `expo-cli` version.
